### PR TITLE
WAK-1759-Small-fix: Fix fonts and dimensions for Image download 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "unpkg": "dist/html-to-image.js",
-  "types": "lib/index.d.ts",
+  "types": "es/index.d.ts",
   "files": [
     "dist",
     "es",


### PR DESCRIPTION
- [x] Type declarations point to `es` directory instead of `lib`